### PR TITLE
refactor: make Colour fields public so that custom colors can be used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catppuccin"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["backwardspy <backwardspy@gmail.com>"]
 edition = "2021"
 description = "🦀 Soothing pastel theme for Rust."

--- a/src/colour.rs
+++ b/src/colour.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, fmt::Debug};
 
 /// A simple three-channel RGB colour representation.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct Colour(pub(crate) u8, pub(crate) u8, pub(crate) u8);
+pub struct Colour(pub u8, pub u8, pub u8);
 
 impl Colour {
     /// Returns a hexadecimal string representing the colour.


### PR DESCRIPTION
# Why

In leu of #6, it'd be nice to be able to modify a specific color in a palette. Since `FlavourColours` has public fields, it's possible to overwrite them, but `Colour` cannot be created outside of the crate