### PR TITLE
feat: expose `order` for flavors and colors

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -39,8 +39,9 @@ struct Color {
 
 #[derive(Debug, Deserialize)]
 struct Flavor {
-    dark: bool,
     emoji: char,
+    order: u32,
+    dark: bool,
     colors: HashMap<String, Color>,
 }
 
@@ -305,10 +306,12 @@ fn make_flavor_entry<W: Write>(
         "Flavor {{
         name: FlavorName::{},
         emoji: '{}',
+        order: {},
         dark: {:?},
         colors: FlavorColors {{",
         titlecase(flavor_key),
         flavor.emoji,
+        flavor.order,
         flavor.dark
     )?;
     for (color_key, color) in &flavor.colors {
@@ -324,12 +327,14 @@ fn make_color_entry<W: Write>(w: &mut W, color: &Color, name: &str) -> Result<()
         w,
         r#"Color {{
                 name: ColorName::{},
+                order: {},
                 accent: {:?},
                 hex: Hex(Rgb {{ r: {:?}, g: {:?}, b: {:?} }}),
                 rgb: Rgb {{ r: {:?}, g: {:?}, b: {:?} }},
                 hsl: Hsl {{ h: {:?}, s: {:?}, l: {:?} }},
             }},"#,
         titlecase(name),
+        color.order,
         color.accent,
         color.rgb.r,
         color.rgb.g,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,8 @@ pub struct Hsl {
 pub struct Color {
     /// The [`ColorName`] for this color.
     pub name: ColorName,
+    /// Order of the color in the palette spec.
+    pub order: u32,
     /// Whether the color is considered an accent color.
     /// Accent colors are the first 14 colors in the palette, also called
     /// the analogous colours. The remaining 12 non-accent colors are also
@@ -161,6 +163,8 @@ pub struct Flavor {
     pub name: FlavorName,
     /// Emoji associated with the flavor. Requires Unicode 13.0 (2020) or later to render.
     pub emoji: char,
+    /// Order of the flavor in the palette spec.
+    pub order: u32,
     /// Whether this flavor is dark or light oriented. Latte is light, the other
     /// three flavors are dark.
     pub dark: bool,


### PR DESCRIPTION
Exposes the `order` property for flavors and colors.