### PR TITLE
fix(deps): use iced_core for color conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ clippy.nursery = "warn"
 ansi_term = { version = "0.12", optional = true }
 bevy = { version = "0.18", default-features = false, optional = true }
 css-colors = { version = "1.0", optional = true }
-iced = { version = "0.14", optional = true }
+iced_core = { version = "0.14", optional = true }
 ratatui-core = { version = "0.1", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
@@ -38,6 +38,7 @@ syn = "2.0"
 
 [dev-dependencies]
 crossterm = "0.29"
+iced = "0.14"
 ratatui = "0.30"
 serde_json = "1.0"
 
@@ -46,7 +47,7 @@ ansi-term = ["dep:ansi_term"]
 bevy = ["bevy/bevy_color"]
 bevy-full = ["bevy/default"]
 css-colors = ["dep:css-colors"]
-iced = ["dep:iced"]
+iced = ["dep:iced_core"]
 ratatui = ["dep:ratatui-core"]
 serde = ["dep:serde"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -698,25 +698,25 @@ mod css_colors {
 mod iced {
     use crate::{AnsiColor, Color};
 
-    impl From<Color> for iced::Color {
+    impl From<Color> for iced_core::Color {
         fn from(value: Color) -> Self {
             Self::from_rgb8(value.rgb.r, value.rgb.g, value.rgb.b)
         }
     }
 
-    impl From<Color> for iced::Background {
+    impl From<Color> for iced_core::Background {
         fn from(value: Color) -> Self {
             Self::Color(value.into())
         }
     }
 
-    impl From<AnsiColor> for iced::Color {
+    impl From<AnsiColor> for iced_core::Color {
         fn from(value: AnsiColor) -> Self {
             Self::from_rgb8(value.rgb.r, value.rgb.g, value.rgb.b)
         }
     }
 
-    impl From<AnsiColor> for iced::Background {
+    impl From<AnsiColor> for iced_core::Background {
         fn from(value: AnsiColor) -> Self {
             Self::Color(value.into())
         }


### PR DESCRIPTION
## Summary

- replace the optional full `iced` dependency with `iced_core`, which owns the converted `Color` and `Background` types
- keep full `iced` as a dev dependency so the existing GUI example still compiles and exercises the conversions
- preserve the public `iced` feature while avoiding renderer, windowing, and executor defaults for downstream users

The normal/build dependency graph for `--no-default-features --features iced` drops from 206 unique packages to 33 (173 fewer, 83.98%).

Closes #77

## Verification

- `cargo check --no-default-features --features iced --lib`
- `cargo check --example iced --features iced`
- `cargo build --features "ansi-term bevy css-colors iced ratatui serde" --verbose`
- `cargo test --features "ansi-term bevy css-colors iced ratatui serde" --verbose`
- `cargo fmt --all --check`
- `cargo check --all-targets --all-features`
- `cargo package --allow-dirty`

`uvx pre-commit run --all-files` reaches an existing Rust 1.97 Clippy failure in `build.rs:212` (`iter_kv_map`), reproduced unchanged on `origin/main`. All other hooks pass for the changed files.